### PR TITLE
Clean up and remove debugging info

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ env:
 # mac configuration
 before_install:
     # first uninstall a conflicting package
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew cask uninstall oclint; fi
+#    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew cask uninstall oclint; fi
 
     # install required packages
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,6 @@ else()
   find_package(LAPACK REQUIRED)
 endif()
 
-
 ########################################################################
 # Test option configuration
 # Do this before configuring modules so that precompiler flags are included

--- a/cmake/OpenfastFortranOptions.cmake
+++ b/cmake/OpenfastFortranOptions.cmake
@@ -39,7 +39,6 @@
 #
 macro(set_fast_fortran)
   get_filename_component(FCNAME "${CMAKE_Fortran_COMPILER}" NAME)
-  message("-------Using compiler  ${FCNAME} -------")
 
   # Abort if we do not have gfortran or Intel Fortran Compiler.
   if (NOT (${CMAKE_Fortran_COMPILER_ID} STREQUAL "GNU" OR

--- a/modules-local/aerodyn14/src/AeroSubs.f90
+++ b/modules-local/aerodyn14/src/AeroSubs.f90
@@ -55,7 +55,6 @@ SUBROUTINE AD14_GetInput(InitInp, P, x, xd, z, m, y, ErrStat, ErrMess )
    character(*), parameter    :: RoutineName = 'AD14_GetInput'
 
    !bjj: error handling here needs to be fixed! (we overwrite any non-AbortErrLev errors)
-   print *, '********************* CP - Inside AeroDyn14!!!'
    
    ErrStat = ErrID_None
    ErrMess = ''

--- a/modules-local/aerodyn14/src/DWM.f90
+++ b/modules-local/aerodyn14/src/DWM.f90
@@ -125,15 +125,10 @@ SUBROUTINE DWM_End( u, p, x, xd, z, OtherState, y, m, ErrStat, ErrMess )
 
          ! Place any last minute operations or calculations here:
       CALL DWM_phase4( u, p, x, xd, z, OtherState, y, m, ErrStat, ErrMess )   
-      print *, "after dwm_phase4"
          
       CALL write_result_file( m, p, y, u )
-
-      print *, "after write_result_file"
       
       CALL InflowWind_End(  u%IfW, p%IfW, x%IfW, xd%IfW, z%IfW, OtherState%IfW, y%IfW, m%IfW, ErrStat, ErrMess )
-      
-      print *, "after inflowWind_End"
 
          ! Close files here:
 
@@ -324,26 +319,19 @@ SUBROUTINE DWM_phase4( u, p, x, xd, z, OtherState, y, m, ErrStat, ErrMess )
          !-------
          
          CALL Get_wake_center ( OtherState, m, p, y, u, x, xd, z, m%WMC%wake_width, y%wake_position )
-         print *, 'after get wake center!'
       
       
          IF (p%RTPD%downwindturbine_number >0 ) THEN
            DO I = 1,p%RTPD%downwindturbine_number
               CALL smooth_out_wake(m, p, y%wake_u,y%wake_position,u%Upwind_result%smoothed_velocity_array(I,:),p%RTPD%downwind_turbine_projected_distance(I),&
                                    p%RTPD%downwind_align_angle(I),u%Upwind_result%vel_matrix(I,:,:))
-
-              print *, 'after smooth out wake'
               u%Upwind_result%TI_downstream (I)             = TI_downstream_total (m, p, y, p%RTPD%downwind_turbine_projected_distance(I),&
                                                               p%RTPD%downwind_align_angle(I),u%Upwind_result%vel_matrix(I,:,:))
-              print *, 'after smooth out wake 2'
               u%Upwind_result%small_scale_TI_downstream (I) = smallscale_TI (m, p, y, p%RTPD%downwind_turbine_projected_distance(I),&
                                                               p%RTPD%downwind_align_angle(I),u%Upwind_result%vel_matrix(I,:,:))
-
-              print *, 'after smooth out wake 3'
               
            END DO
          END IF
-              print *, 'end of function'
       
       
 END SUBROUTINE DWM_phase4

--- a/modules-local/aerodyn14/src/DWM_Wake_Sub_ver2.f90
+++ b/modules-local/aerodyn14/src/DWM_Wake_Sub_ver2.f90
@@ -390,7 +390,6 @@ SUBROUTINE calculate_mean_u( m, p, u, num_element,r_t,turbine_mean_velocity,TI_n
             DO I = 1,p%RTPD%upwindturbine_number               
                TI_normalization = (TI_normalization**2 + u%Upwind_result%upwind_TI(I)**2)**0.5
             END DO
-
             !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
            TI_normalization = u%Upwind_result%upwind_TI(1)          ! only take the TI effect from the closest upstream turbine
             !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%           
@@ -1563,7 +1562,6 @@ SUBROUTINE Get_wake_center ( OS, m, p, y, u, x, xd, z, wakewidth, wake_center )
     DWM_time_step = (2*p%RotorR/m%DWDD%ppR)/Modified_U          ! resolution (126m/50) / wind speed (8m/s) => make sure there is always a wake width at every time step
                                                   ! D/(DWM_time_step*Mean_FFWS)= 50 which is the X resolution
 
-
     U_Scale_Factor =  Modified_U / (p%Uambient*U_factor)       ! modify the wake displacement error caused by the change of Mean_FFWS                                                                                        
     
     U_Scale_Factor = 1                       ! 7.15.2015
@@ -1577,26 +1575,21 @@ SUBROUTINE Get_wake_center ( OS, m, p, y, u, x, xd, z, wakewidth, wake_center )
     release_time      = simulation_time_length       
     flying_time       = m%meandering_data%moving_time       
     m%meandering_data%scale_factor      = 10       ! to decrease the calculation time
-
     ALLOCATE (wake_center (release_time,flying_time+1,3) )
                                  ! ex. @8D: (1~release_time,8*[ppR/scale_factor]+1,:)
 
-
     DO release_time = 1,simulation_time_length,1               ! wake center position at turbine plane
-
        wake_center (release_time,1,1) = 0
        wake_center (release_time,1,2) = 0
        wake_center (release_time,1,3) = REAL(p%hub_height,ReKi)
     END DO
     
     x_step = Modified_U * (DWM_time_step*m%meandering_data%scale_factor)
-
     
     IF (.NOT. ALLOCATED(u%IfW%PositionXYZ) ) THEN
        CALL AllocAry( u%IfW%PositionXYZ, 3, 1, "Position array to send to IfW_CalcOutput", ErrStat, ErrMsg )
        IF (ErrStat >= AbortErrLev)  RETURN
     END IF
-
 
     
     ! get the initial wake center position of each cross scetion  (from the velocity at the turbine plane * dt)
@@ -1604,13 +1597,11 @@ SUBROUTINE Get_wake_center ( OS, m, p, y, u, x, xd, z, wakewidth, wake_center )
        wake_center (release_time,2,1) = Modified_U * (DWM_time_step*m%meandering_data%scale_factor) +0             
 
 
-
        !temp_center_wake (:) = AD_WindVelocityWithDisturbance(  (REAL(((release_time-1)+1)*DWM_time_step*m%meandering_data%scale_factor,ReKi)), &
                                              !A_u, A_p, A_x, A_xd, A_z, A_O, A_y, ErrStat, ErrMsg, (/0.0,REAL(0,ReKi),REAL(p%TurbRefHt,ReKi)/) )
                            !AD_GetUndisturbedWind ( (REAL(((release_time-1)+1)*DWM_time_step*m%meandering_data%scale_factor,ReKi)), (/0.0,&                  
                                                 !REAL(0,ReKi),REAL(p%TurbRefHt,ReKi)/), ErrStat)                                ! get the velocity at the turbine plane
                                                 
-
        u%IfW%PositionXYZ(1,1) = (0.0_ReKi)
        u%IfW%PositionXYZ(2,1) = (0.0_ReKi)
        u%IfW%PositionXYZ(3,1) = (p%hub_height)
@@ -1627,7 +1618,6 @@ SUBROUTINE Get_wake_center ( OS, m, p, y, u, x, xd, z, wakewidth, wake_center )
                                         !rotation_lateral_offset( wake_center (release_time,2,1) )
                                         
        wake_center (release_time,2,3) = temp_center_wake (3) * (DWM_time_step*m%meandering_data%scale_factor) * U_Scale_Factor + wake_center (release_time,1,3)
-
     END DO
 
 
@@ -1637,7 +1627,6 @@ SUBROUTINE Get_wake_center ( OS, m, p, y, u, x, xd, z, wakewidth, wake_center )
    
        temp_velocity(:) = filter_velocity (OS,m,p,u,x,xd,z,y,((release_time-1)+1)*DWM_time_step*m%meandering_data%scale_factor, wake_center (release_time,flying_time+1-1,2), &
                                           wake_center (release_time,flying_time+1-1,3), wakewidth((flying_time-1)*m%meandering_data%scale_factor) )
-
 
        !!!--------- temp data------
        test_1 = temp_velocity (2) * (DWM_time_step*m%meandering_data%scale_factor) * U_Scale_Factor  + wake_center (release_time,flying_time,2)+ &
@@ -1654,7 +1643,6 @@ SUBROUTINE Get_wake_center ( OS, m, p, y, u, x, xd, z, wakewidth, wake_center )
    
    
        END DO
-    print *, '...'
     END DO
     
 

--- a/modules-local/nwtc-library/src/NWTC_IO.f90
+++ b/modules-local/nwtc-library/src/NWTC_IO.f90
@@ -6058,55 +6058,6 @@ QueryGitVersion = GIT_VERSION_INFO
 
    RETURN
    END SUBROUTINE ReadR4Var
-
-!=======================================================================
-!> \copydoc nwtc_io::readcvar
-   SUBROUTINE ReadR_wm_Var ( UnIn, Fil, Var, VarName, VarDescr, ErrStat, ErrMsg, UnEc )
-
-
-      ! This routine reads a single double (real) variable from the next line of the input file.
-      ! New code should call ReadVar instead of directly calling this routine.
-
-
-      ! Argument declarations:
-
-   REAL,    INTENT(OUT)         :: Var                                             ! Real variable being read.
-   INTEGER(IntKi),INTENT(OUT)         :: ErrStat                                         ! Error status; if present, program does not abort on error
-   CHARACTER(*),  INTENT(OUT)         :: ErrMsg                                          ! Error message
-
-   INTEGER,       INTENT(IN)          :: UnIn                                            ! I/O unit for input file.
-   INTEGER,       INTENT(IN), OPTIONAL:: UnEc                                            ! I/O unit for echo file. If present and > 0, write to UnEc
-
-   CHARACTER( *), INTENT(IN)          :: Fil                                             ! Name of the input file.
-   CHARACTER( *), INTENT(IN)          :: VarDescr                                        ! Text string describing the variable.
-   CHARACTER( *), INTENT(IN)          :: VarName                                         ! Text string containing the variable name.
-
-
-      ! Local declarations:
-
-   INTEGER                            :: IOS                                             ! I/O status returned from the read statement.
-   CHARACTER(30)                      :: Word                                            ! String to hold the first word on the line.
-
-
-
-   CALL ReadNum ( UnIn, Fil, Word, VarName, ErrStat, ErrMsg )
-   IF ( ErrStat >= AbortErrLev) RETURN  ! If we're about to read a T/F and treat it as a number, we have a less severe ErrStat
-
-
-   READ (Word,*,IOSTAT=IOS)  Var
-
-   CALL CheckIOS ( IOS, Fil, VarName, NumType, ErrStat, ErrMsg )
-
-   IF (ErrStat >= AbortErrLev) RETURN
-
-
-   IF ( PRESENT(UnEc) )  THEN
-      IF ( UnEc > 0 ) &
-         WRITE (UnEc,Ec_ReFrmt)  Var, VarName, VarDescr
-   END IF
-
-   RETURN
-   END SUBROUTINE ReadR_wm_Var
 !=======================================================================
 !> \copydoc nwtc_io::readivarwdefault
    SUBROUTINE ReadR4VarWDefault ( UnIn, Fil, Var, VarName, VarDescr, VarDefault, ErrStat, ErrMsg, UnEc )

--- a/modules-local/openfast-library/src/FAST_Subs.f90
+++ b/modules-local/openfast-library/src/FAST_Subs.f90
@@ -1455,7 +1455,6 @@ SUBROUTINE GetInputFileName(InputFile,UseDWM,ErrStat,ErrMsg)
    IF (LEN_TRIM(LastArg) > 0) THEN ! see if DWM was specified as the second option
       CALL Conv2UC( LastArg )
       IF ( TRIM(LastArg) == "DWM" ) THEN
-         PRINT *, "Using the DWM module."
          UseDWM    = .TRUE.
       END IF
    END IF   


### PR DESCRIPTION
Here's another minor commit to clean things up a bit more. Ultimately, I want only the changes to the DWM driver code and cmake configuration in the pull request, and I think this will get it really close.

I removed a subroutine you had added to NWTC_IO, `ReadR_wm_Var`, because I didn't see it used anywhere. Is this something you need or was it included accidentally?